### PR TITLE
Fix mobile image cropping

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -160,9 +160,10 @@
         gap: 10px;
       }
 
-      .gallery img {
-        height: 130px;
-      }
+        .gallery img {
+          height: auto;
+          object-fit: contain;
+        }
 
       .animal-bar {
         gap: 12px;


### PR DESCRIPTION
## Summary
- avoid cropping gallery images on mobile

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6843fe2e1abc83259809903f7c9a811a