### PR TITLE
Add construction banner with typing animation

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -231,6 +231,12 @@
         stroke-dashoffset: 0;
       }
     }
+
+    #construction-banner {
+      font-family: 'EB Garamond', Georgia, 'Times New Roman', Times, serif;
+      text-align: center;
+      margin-top: 1em;
+    }
   </style>
 
   </style>
@@ -238,6 +244,7 @@
 </head>
 
 <body>
+  <div id="construction-banner"></div>
   <div class="animal-bar">
     <button class="animal-btn" onclick="randomizeAnimal(this)">
       <img src="{{ url_for('static', filename='animals/bear.png') }}" alt="Animal" />
@@ -377,6 +384,7 @@
 
     window.onload = function () {
       typeWriter(document.getElementById("main-heading"), "Squawk", 550);
+      typeWriter(document.getElementById("construction-banner"), "This bad boy is currently under construction...");
     };
   </script>
 


### PR DESCRIPTION
## Summary
- add a new banner at the top of about page
- style the banner to use EB Garamond and center it
- animate the banner text with the existing typeWriter function

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a20a2b0a48325a96bf7b70212d76c