### PR TITLE
Implement gallery image preload

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -294,6 +294,17 @@
           img.style.filter = 'contrast(1.15) saturate(1.1)';
         }
       }
+
+      // Preload the remix versions of gallery images so swapping is seamless
+      window.addEventListener('DOMContentLoaded', () => {
+        document.querySelectorAll('.gallery img').forEach(imgEl => {
+          const remixSrc = imgEl.getAttribute('data-remix');
+          if (remixSrc) {
+            const preloadImg = new Image();
+            preloadImg.src = remixSrc;
+          }
+        });
+      });
     </script>
 
   </div>


### PR DESCRIPTION
## Summary
- preload gallery remix images so they show up instantly when swapped

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684bae52b870832598829d451b021f3a